### PR TITLE
Fix indexUrl command

### DIFF
--- a/.changeset/slow-moons-play.md
+++ b/.changeset/slow-moons-play.md
@@ -1,0 +1,5 @@
+---
+"@team-plain/cli": patch
+---
+
+Fix non awaited promise

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ function handleError(message, requestId = "–") {
 
 async function indexUrl(url, labelTypeIds = []) {
 	const client = getClient();
-	const res = client.indexDocument({
+	const res = await client.indexDocument({
 		url,
 		labelTypeIds,
 	});


### PR DESCRIPTION
Errors are not handled correctly as we're not awaiting the result of the client call