### PR TITLE
Update index-url mutation

### DIFF
--- a/.changeset/little-peaches-report.md
+++ b/.changeset/little-peaches-report.md
@@ -1,0 +1,5 @@
+---
+"@team-plain/cli": minor
+---
+
+Use knowledge source for index URL

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@changesets/cli": "^2.27.9"
 	},
 	"dependencies": {
-		"@team-plain/typescript-sdk": "^5.10.0",
+		"@team-plain/typescript-sdk": "^5.10.2",
 		"commander": "^12.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@changesets/cli": "^2.27.9"
 	},
 	"dependencies": {
-		"@team-plain/typescript-sdk": "^5.10.2",
+		"@team-plain/typescript-sdk": "^5.10.3",
 		"commander": "^12.1.0"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,19 +28,6 @@ function handleError(message, requestId = "–") {
 	process.exit(1);
 }
 
-async function indexUrl(url, labelTypeIds = []) {
-	const client = getClient();
-	const res = await client.indexDocument({
-		url,
-		labelTypeIds,
-	});
-	if (res.error) {
-		handleError(res.error.message, res.error.requestId);
-	} else {
-		console.log(`✅ Successfully indexed ${url}`);
-	}
-}
-
 program.name("plain").version(packageJson.version).description("Plain CLI");
 
 program
@@ -51,7 +38,19 @@ program
 	.argument("<url>")
 	.option("-l, --labelTypeIds <labelTypeIds...>", "Array of label type IDs")
 	.action(async (url, options) => {
-		await indexUrl(url, options.labelTypeIds);
+		const client = getClient();
+		const res = await client.createKnowledgeSource({
+			url,
+			labelTypeIds: options.labelTypeIds || [],
+			type: "URL",
+		});
+		if (res.error) {
+			handleError(res.error.message, res.error.requestId);
+		} else {
+			console.log(
+				`✅ Successfully indexed URL ${url} - The URL will be indexed and knowledge sources will be available in Plain. See https://plain.support.site/article/plain-ai-knowledge-sources for more information.`,
+			);
+		}
 	});
 
 program


### PR DESCRIPTION
This PR updates the underlying mutation called for `index-url` due to internal refactoring, the functionality remains unchanged.